### PR TITLE
Add AMD/CommonJS support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.DS_Store

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+node_modules
+docs

--- a/README.md
+++ b/README.md
@@ -1,5 +1,17 @@
 # currencyFormatter.js
 A super simple currency formatting library
 
+## Instalation
 
+### npm
+```Bash
+npm install currencyformater.js
+```
+
+### bower
+```Bash
+bower install currencyformater.js
+```
+
+## Docs
 [Full docs available here ](https://osrec.github.io/currencyFormatter.js/)

--- a/currencyFormatter.js
+++ b/currencyFormatter.js
@@ -4,20 +4,6 @@
 
 var OSREC = OSREC || {};
 
-var hasDefine = typeof define === 'function';
-var hasExports = typeof module !== 'undefined' && module['exports'];
-var root = (typeof window === 'undefined') ? global : window;
-
-if (hasDefine) { // AMD Module
-  define([], function() {
-    return CurrencyFormatter;
-  });
-} else if (hasExports) { // Node.js Module
-  module['exports'] = CurrencyFormatter;
-} else { // Assign to the global object
-  root['OSREC'] = OSREC;
-}
-
 OSREC.CurrencyFormatter =
 {
 	symbols:
@@ -1305,3 +1291,17 @@ OSREC.CurrencyFormatter =
 		return formatterFunction(n);
 	}
 };
+
+var hasDefine = typeof define === 'function';
+var hasExports = typeof module !== 'undefined' && module['exports'];
+var root = (typeof window === 'undefined') ? global : window;
+
+if (hasDefine) { // AMD Module
+  define([], function() {
+    return CurrencyFormatter;
+  });
+} else if (hasExports) { // Node.js Module
+  module['exports'] = CurrencyFormatter;
+} else { // Assign to the global object
+  root['OSREC'] = OSREC;
+}

--- a/currencyFormatter.js
+++ b/currencyFormatter.js
@@ -4,10 +4,10 @@
 
 var OSREC = OSREC || {};
 
-OSREC.CurrencyFormatter =
+OSREC.CurrencyFormatter = 
 {
 	symbols:
-	{
+	{	
 		AED:'&#x62f;&#x2e;&#x625;&#x2e;&#x200f;',
 		AFN:'&#x60b;',
 		ALL:'&#x4c;&#x65;&#x6b;&#xeb;',
@@ -162,7 +162,7 @@ OSREC.CurrencyFormatter =
 		ZMW:'&#x4b;'
 	},
 
-	defaultLocales:
+	defaultLocales: 
 	{
 		AED: 'ar_AE',
 		AFN: 'fa_AF',
@@ -319,9 +319,9 @@ OSREC.CurrencyFormatter =
 		ZAR: 'zu',
 		ZMW: 'en_ZM',
 		ZWL: 'en_ZW',
-
+		
 	},
-
+	
 	locales:
 	{
 		af: { p: '!#,##0.00', g: ' ', d: ',' },
@@ -1040,197 +1040,197 @@ OSREC.CurrencyFormatter =
 		zu: { p: '!#,##0.00', g: ',', d: '.' },
 		zu_ZA: { h: 'zu' },
 	},
-
+	
 	getFormatter: function(p)
 	{
 		var locales 		= OSREC.CurrencyFormatter.locales;
 		var defaultLocales 	= OSREC.CurrencyFormatter.defaultLocales;
 		var symbols 		= OSREC.CurrencyFormatter.symbols;
-
+		
 		var locale, currency, symbol, pattern, decimal, group;
-
+		
 		// Helper Functions
-
+		
 		var isUndefined = function(o)
 		{
 			return (typeof o === 'undefined');
 		};
-
-		var toFixed = function( n, precision )
+		
+		var toFixed = function( n, precision ) 
 		{
 			return (+(Math.round(+(n + 'e' + precision)) + 'e' + -precision)).toFixed(precision);
 		};
-
+		
 		// Perform checks on inputs and set up defaults as needed (defaults to en, USD)
-
+		
 		if(isUndefined(p)) { p = {}; }
-
+		
 		currency 	= isUndefined(p.currency)? 'USD' : p.currency.toUpperCase();
 		locale 		= isUndefined(p.locale) ? locales[defaultLocales[currency]] : locales[p.locale];
-
+		
 		if(!isUndefined(locale.h)) locale = locales[locale.h]; // Locale inheritance
-
+		
 		symbol 		= isUndefined(p.symbol) ? symbols[currency] : p.symbol;
-
+		
 		if(isUndefined(symbol)) symbol = currency; // In case we don't have the symbol, just use the ccy code
 
 		pattern 	= isUndefined(p.pattern) ? locale.p : p.pattern;
 		decimal		= isUndefined(p.decimal) ? locale.d : p.decimal;
 		group 		= isUndefined(p.group) ? locale.g : p.group;
-
+		
 		//console.log(locale);
-
+		
 		// encodePattern Function - returns a few simple characteristics of the pattern provided
-
+		
 		var encodePattern = function(pattern)
 		{
 			var decimalPlaces = 0;
 			var frontPadding = '';
 			var backPadding = '';
 			var groupLengths = [];
-
+			
 			//console.log(pattern);
-
+				
 			var patternStarted = false;
 			var decimalsStarted = false;
 			var patternEnded = false;
-
-
+			
+			
 			var currentGroupLength = 0;
 			var zeroLength = 0;
-
+			
 			for(var i = 0; i < pattern.length; ++i )
 			{
 				var c = pattern[i];
-
-				if(!patternStarted && ['#','0',',','.'].indexOf(c) > -1)
-				{
-					patternStarted = true;
+				
+				if(!patternStarted && ['#','0',',','.'].indexOf(c) > -1) 
+				{ 
+					patternStarted = true; 
 				}
 
 				if(!patternStarted) { frontPadding += c; }
 
 				switch (c)
-				{
+				{							
 					case '#':
 						++currentGroupLength;
 						break;
-
+						
 					case '0':
 						if(decimalsStarted) {  ++decimalPlaces; }
 						else { ++currentGroupLength; ++zeroLength; }
 						break;
-
+					
 					case ',':
 						groupLengths.push(currentGroupLength);
 						currentGroupLength = 0;
 						break;
-
+										
 					case '.':
 						groupLengths.push(currentGroupLength);
 						decimalsStarted = true;
 						break;
 				}
-
+				
 				if(patternStarted && !(['#','0',',','.'].indexOf(c) > -1))
-				{
+				{ 
 					patternEnded = true;
-
+					
 					if(!decimalsStarted)
 					{
 						groupLengths.push(currentGroupLength);
 					}
-
+					
 				}
-
+				
 				if(patternEnded) { backPadding += c; }
 			}
-
-			var encodedPattern =
-			{
+			
+			var encodedPattern = 
+			{ 
 				decimalPlaces: decimalPlaces,
 				frontPadding: frontPadding,
 				backPadding: backPadding,
 				groupLengths: groupLengths,
 				zeroLength: zeroLength
 			};
-
+			
 			return encodedPattern;
-		};
+		};		
 
 		// Zero Padding helper function
-
-		var pad = function(n, width)
+		
+		var pad = function(n, width) 
 		{
 			n = n + '';
 			return n.length >= width ? n : new Array(width - n.length + 1).join('0') + n;
-		}
-
+		}		
+				
 		// Format function
-
+		
 		var format = function(n, f)
 		{
 			var formattedNumber = toFixed(Math.abs(n), f.decimalPlaces);
-
+			
 			var splitNumber = formattedNumber.split(".");
-
+			
 			if(f.groupLengths.length > 1)	// i.e. we actually have some sort of grouping in the values
 			{
 				var segment = "";
-
+				
 				var cursor = splitNumber[0].length;
-
+				
 				var groupIndex = f.groupLengths.length - 1;
-
-				while(cursor > 0)
+				
+				while(cursor > 0) 
 				{
 					if(groupIndex <= 0) { groupIndex = 1; } // Always reset to the first group length if the number is big
-
+					
 					var currentGroupLength = f.groupLengths[groupIndex];
-
+					
 					var start = cursor-currentGroupLength;
-
+					
 					segment = splitNumber[0].substring(start, cursor) + f.group + segment;
-
+					
 					cursor -= currentGroupLength;
-
+					
 					--groupIndex;
 				}
-
+				
 				segment = segment.substring(0, segment.length-1);
 				//console.log(segment);
 			}
-
+			
 			if(segment.length < f.zeroLength) { segment = pad(segment, f.zeroLength); }
-
-			var formattedNumber = f.frontPadding + segment + ( isUndefined(splitNumber[1]) ? '' : (f.decimal + splitNumber[1]) ) + f.backPadding;
-
+			
+			var formattedNumber = f.frontPadding + segment + ( isUndefined(splitNumber[1]) ? '' : (f.decimal + splitNumber[1]) ) + f.backPadding; 
+			
 			return formattedNumber.replace('!', symbol);
-
+			
 		};
-
+		
 		// Use encode function to work out pattern
-
+		
 		var patternArray = pattern.split(";");
-
+				
 		var positiveFormat = encodePattern(patternArray[0]);
-
+		
 		positiveFormat.symbol = symbol;
 		positiveFormat.decimal = decimal;
-		positiveFormat.group = group;
-
+		positiveFormat.group = group;		
+		
 		var negativeFormat = isUndefined(patternArray[1]) ? encodePattern("-" + patternArray[0]) : encodePattern(patternArray[1]);
-
+		
 		negativeFormat.symbol = symbol;
 		negativeFormat.decimal = decimal;
-		negativeFormat.group = group;
-
+		negativeFormat.group = group;			
+		
 		var zero = isUndefined(patternArray[2]) ? format(0, positiveFormat) : patternArray[2];
-
+		
 		if(!isUndefined(patternArray[2])) { zeroFormat = patternArray[2]; }
 
-
-
+	
+		
 		return function(n)
 		{
 			var formattedNumber;
@@ -1240,41 +1240,41 @@ OSREC.CurrencyFormatter =
 			else { formattedNumber = format(n, negativeFormat);	}
 			return formattedNumber;
 		};
-
+		
 	},
-
+	
 	formatAll: function(p)
 	{
 		var formatter = OSREC.CurrencyFormatter.getFormatter(p);
-
+		
 		var matches = document.querySelectorAll(p.selector);
-
-		for (i = 0; i < matches.length; ++i)
+				
+		for (i = 0; i < matches.length; ++i) 
 		{
 			matches[i].innerHTML = formatter(matches[i].textContent);
 		}
 	},
-
+	
 	formatEach: function(selector)
 	{
 		var formatters = {}
-
+		
 		var matches = document.querySelectorAll(selector);
-
-		for (i = 0; i < matches.length; ++i)
+		
+		for (i = 0; i < matches.length; ++i) 
 		{
 			try
 			{
-
+				
 				var ccy = matches[i].getAttribute("data-ccy");
-
+				
 				if (typeof formatters[ccy] === 'undefined')
 				{
 					formatters[ccy] = OSREC.CurrencyFormatter.getFormatter({currency: ccy});
 				}
-
+				
 				var formatter = formatters[ccy];
-
+				
 				matches[i].innerHTML = formatter(matches[i].textContent);
 			}
 			catch (e)
@@ -1282,15 +1282,17 @@ OSREC.CurrencyFormatter =
 				console.log(e);
 			}
 		}
-	},
-
+	},	
+	
 	format: function(n, p)
 	{
 		var formatterFunction = OSREC.CurrencyFormatter.getFormatter(p);
-
+		
 		return formatterFunction(n);
 	}
 };
+
+
 
 var hasDefine = typeof define === 'function';
 var hasExports = typeof module !== 'undefined' && module.exports;

--- a/currencyFormatter.js
+++ b/currencyFormatter.js
@@ -1298,10 +1298,10 @@ var root = (typeof window === 'undefined') ? global : window;
 
 if (hasDefine) { // AMD Module
   define([], function() {
-    return CurrencyFormatter;
+    return OSREC.CurrencyFormatter;
   });
 } else if (hasExports) { // Node.js Module
-  module.exports = CurrencyFormatter;
+  module.exports = OSREC.CurrencyFormatter;
 } else { // Assign to the global object
 	// This makes sure that the object really is assigned tot he global scope
   root.OSREC = OSREC;

--- a/currencyFormatter.js
+++ b/currencyFormatter.js
@@ -1293,7 +1293,7 @@ OSREC.CurrencyFormatter =
 };
 
 var hasDefine = typeof define === 'function';
-var hasExports = typeof module !== 'undefined' && module['exports'];
+var hasExports = typeof module !== 'undefined' && module.exports;
 var root = (typeof window === 'undefined') ? global : window;
 
 if (hasDefine) { // AMD Module
@@ -1301,7 +1301,8 @@ if (hasDefine) { // AMD Module
     return CurrencyFormatter;
   });
 } else if (hasExports) { // Node.js Module
-  module['exports'] = CurrencyFormatter;
+  module.exports = CurrencyFormatter;
 } else { // Assign to the global object
-  root['OSREC'] = OSREC;
+	// This makes sure that the object really is assigned tot he global scope
+  root.OSREC = OSREC;
 }

--- a/currencyFormatter.js
+++ b/currencyFormatter.js
@@ -1298,13 +1298,19 @@ var hasDefine = typeof define === 'function';
 var hasExports = typeof module !== 'undefined' && module.exports;
 var root = (typeof window === 'undefined') ? global : window;
 
-if (hasDefine) { // AMD Module
-  define([], function() {
-    return OSREC.CurrencyFormatter;
-  });
-} else if (hasExports) { // Node.js Module
-  module.exports = OSREC.CurrencyFormatter;
-} else { // Assign to the global object
-	// This makes sure that the object really is assigned tot he global scope
-  root.OSREC = OSREC;
+if (hasDefine) 
+{
+	// AMD Module
+	define([], function() { return OSREC.CurrencyFormatter; });
+} 
+else if (hasExports) 
+{
+	// Node.js Module
+  	module.exports = OSREC.CurrencyFormatter;
+}
+else 
+{ 
+	// Assign to the global object
+	// This makes sure that the object really is assigned to the global scope
+  	root.OSREC = OSREC;
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "currencyformatter.js",
+  "version": "1.0.2",
+  "description": "A super simple currency formatting library",
+  "main": "currencyFormatter.js",
+  "directories": {
+    "doc": "docs"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/osrec/currencyFormatter.js.git"
+  },
+  "keywords": [
+    "currency",
+    "javascript",
+    "money",
+    "formatting",
+    "decimal"
+  ],
+  "author": "OSREC <info@osrec.co.uk>",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/osrec/currencyFormatter.js/issues"
+  },
+  "homepage": "https://github.com/osrec/currencyFormatter.js#readme"
+}


### PR DESCRIPTION
This PR contains the following
- [AMD](https://en.wikipedia.org/wiki/Asynchronous_module_definition) and [CommonJS](http://wiki.commonjs.org/wiki/CommonJS) (node.js) support
- Adds a package.json that's required for publishing the library to npm
- Updated readme with bower/npm isntall instructions

What still needs to be done:
- [Publish to npm](https://docs.npmjs.com/getting-started/publishing-npm-packages)
- Create a minified version (I'm not sure how this is done)
- Modify the docs, because both AMD and CommonJS are exposing only the `CurrencyFormatter` object, not the whole `OSREC`.