### PR TITLE
Fix IE11 compatibility.

### DIFF
--- a/currencyFormatter.js
+++ b/currencyFormatter.js
@@ -1259,7 +1259,7 @@ OSREC.CurrencyFormatter =
 	{
 		var decimal = OSREC.CurrencyFormatter.getFormatDetails(p).decimal;
 		var mult = str.indexOf('-') >= 0 ? -1 : 1;
-		return Math.abs(Number(str.replace(new RegExp(`[^0-9${decimal}]`, 'g'), '').replace(decimal, '.'))) * mult;
+		return Math.abs(Number(str.replace(new RegExp('[^0-9' + decimal + ']', 'g'), '').replace(decimal, '.'))) * mult;
 	}
 };
 


### PR DESCRIPTION
IE 11 does not support template literals. This commit removes all of those to provide IE11 working version, which is supported by Microsoft until 2025. (IE11 will be updated as long as the supported operating system is supported, which is 2020 for Win7 etc, and 2025 for Windows 10.)