### PR TITLE
Add currency symbol for RON

### DIFF
--- a/currencyFormatter.js
+++ b/currencyFormatter.js
@@ -126,6 +126,7 @@ OSREC.CurrencyFormatter =
 		PLN: 'zł',
 		PYG: '₲',
 		QAR: 'ر.ق.‏',
+		RON: 'lei',
 		RSD: 'дин.',
 		RUB: '₽',
 		RWF: 'RF',


### PR DESCRIPTION
Add missing currency symbol for the Romanian leu